### PR TITLE
Linker's objects/libraries order changed

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -32,7 +32,7 @@ PROG  = ./kvazaar
 PROGS = $(PROG)
 
 $(PROG): $(OBJS) $(ASMOBJS)
-	$(LD) $(LDFLAGS) $^ -o $@
+	$(LD) $^ $(LDFLAGS) -o $@
 
 test.o: x86/test.asm
 	$(YASM) -f elf x86/test.asm -o test.o


### PR DESCRIPTION
The gcc linker needs to parse object files before parsing and linking the necessary libraries
