### PR TITLE
Avoid reading one extra frame at the end of the input file.

### DIFF
--- a/src/encmain.c
+++ b/src/encmain.c
@@ -181,12 +181,16 @@ int main(int argc, char *argv[])
   encoder->in.cur_pic->pred_v = MALLOC(pixel, (cfg->width * cfg->height) >> 2);
 
   // Start coding cycle while data on input and not on the last frame
-  while(!feof(input) && (!cfg->frames || encoder->frame < cfg->frames)) {
+  while(!cfg->frames || encoder->frame < cfg->frames) {
     int32_t diff;
     double temp_psnr[3];
 
     // Read one frame from the input
-    read_one_frame(input, encoder);
+    if (!read_one_frame(input, encoder)) {
+      if (!feof(input))
+        printf("Failed to read a frame %d\n", encoder->frame);
+      break;
+    }
 
     // The actual coding happens here, after this function we have a coded frame
     encode_one_frame(encoder);    

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -86,7 +86,7 @@ encoder_control *init_encoder_control(config *cfg);
 void init_encoder_input(encoder_input *input, FILE* inputfile,
                         int32_t width, int32_t height);
 void encode_one_frame(encoder_control *encoder);
-void read_one_frame(FILE *file, encoder_control *encoder);
+int read_one_frame(FILE *file, encoder_control *encoder);
 
 void encode_seq_parameter_set(encoder_control *encoder);
 void encode_pic_parameter_set(encoder_control *encoder);


### PR DESCRIPTION
This patch fixes that the encoder tries to read one extra frame beyond the end of input file and generates a garbage frame.
