### PR TITLE
Link dynamically on Linux

### DIFF
--- a/.travis-script.sh
+++ b/.travis-script.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 set -ev
 
+ver_major=$(grep -e '^VER_MAJOR' src/Makefile | sed -e 's/VER_MAJOR//g; s/=//g; s/ //g;')
+ver_minor=$(grep -e '^VER_MINOR' src/Makefile | sed -e 's/VER_MINOR//g; s/=//g; s/ //g;')
+ver_release=$(grep -e '^VER_RELEASE' src/Makefile | sed -e 's/VER_RELEASE//g; s/=//g; s/ //g;')
+libkvazaar=libkvazaar.so.${ver_major}.${ver_minor}.${ver_release}
+
 if [ -n "$VALGRIND_TEST" ]; then
   cd src
   make debug
@@ -9,7 +14,7 @@ elif [ -n "$EXPECTED_STATUS" ]; then
   cd src
   make cli
   set +e
-  ./kvazaar $PARAMS
+  LD_PRELOAD=./$libkvazaar ./kvazaar $PARAMS
   EXIT_STATUS=$?
   set -e
   [ "$EXIT_STATUS" = "$EXPECTED_STATUS" ]

--- a/src/Makefile
+++ b/src/Makefile
@@ -93,6 +93,7 @@ ifeq ($(SYSTEM), Windows)
   endif
   CFLAGS += -D__USE_MINGW_ANSI_STDIO=1
   LIBKVAZAAR_SHARED = $(DLL)
+  KVAZAAR_LIBS = $(STATIC)
   INSTALL_TARGETS += install-dll
 
 # OS X specific flags
@@ -104,17 +105,21 @@ else ifeq ($(SYSTEM), Darwin)
   endif
   ASFLAGS += -DPREFIX
   LIBKVAZAAR_SHARED = $(DYLIB)
+  KVAZAAR_LIBS = $(STATIC)
   INSTALL_TARGETS += install-dylib
 
 # Default to Linux/elf specific flags
 else
   LIBS += -lrt
+  CFLAGS += -ffunction-sections -fdata-sections
+  LDFLAGS += -Wl,--gc-sections
   ifeq ($(ARCH), x86_64)
     ASFLAGS += -f elf64
   else
     ASFLAGS += -f elf32
   endif
   LIBKVAZAAR_SHARED = $(LIB)
+  KVAZAAR_LIBS = $(LIBKVAZAAR_SHARED) $(STATIC)
   INSTALL_TARGETS += install-lib
 endif
 
@@ -253,7 +258,7 @@ $(DYLIB): LDFLAGS += -dynamiclib \
                      -compatibility_version $(VER_MAJOR) \
                      -install_name $(LIBDIR)/$@
 
-$(PROG): $(MAIN_OBJS) $(STATIC)
+$(PROG): $(MAIN_OBJS) $(KVAZAAR_LIBS)
 	$(LD) $^ $(LDFLAGS) $(LIBS) -o $@
 
 $(STATIC): $(OBJS)


### PR DESCRIPTION
Packagers usually prefer the programs to be linked against shared libraries.

Without the flags `-ffunction-sections -fdata-sections` and `-Wl,--gc-sections` I get the following warnings (gcc 4.8.4, GNU ld 2.24):
```
/usr/bin/ld: warning: type and size of dynamic symbol `kvz_satd_32x32_avx' are not defined
/usr/bin/ld: warning: type and size of dynamic symbol `kvz_sad_4x4_stride_avx' are not defined
/usr/bin/ld: warning: type and size of dynamic symbol `kvz_satd_64x64_avx' are not defined
/usr/bin/ld: warning: type and size of dynamic symbol `kvz_sad_8x8_avx' are not defined
/usr/bin/ld: warning: type and size of dynamic symbol `kvz_satd_4x4_avx' are not defined
/usr/bin/ld: warning: type and size of dynamic symbol `kvz_sad_16x16_avx' are not defined
/usr/bin/ld: warning: type and size of dynamic symbol `kvz_sad_4x4_avx' are not defined
/usr/bin/ld: warning: type and size of dynamic symbol `kvz_sad_16x16_stride_avx' are not defined
/usr/bin/ld: warning: type and size of dynamic symbol `kvz_satd_16x16_avx' are not defined
/usr/bin/ld: warning: type and size of dynamic symbol `kvz_satd_8x8_avx' are not defined
/usr/bin/ld: warning: type and size of dynamic symbol `kvz_sad_8x8_stride_avx' are not defined
```