### PR TITLE
build: Drop the gnu-only option Deterministic

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -259,7 +259,7 @@ $(PROG): $(MAIN_OBJS) $(STATIC)
 
 $(STATIC): $(OBJS)
 	$(RM) $@
-	$(AR) rcD $@ $^
+	$(AR) rc $@ $^
 	$(RANLIB) $@
 
 $(LIB) $(DLL) $(DYLIB): $(SHARED_OBJS)


### PR DESCRIPTION
Unbreak building on MacOSX and possibly other BSDs.