### PR TITLE
Only use version prefix in kvazaar binary

### DIFF
--- a/src/global.h
+++ b/src/global.h
@@ -182,7 +182,7 @@ typedef int16_t coeff_t;
 // NOTE: When making a release, check to see if incrementing libversion in 
 // configure.ac is necessary.
 #ifndef KVZ_VERSION
-#define KVZ_VERSION v0.8.3
+#define KVZ_VERSION 0.8.3
 #endif
 #define VERSION_STRING QUOTE_EXPAND(KVZ_VERSION)
 

--- a/tools/version.sh
+++ b/tools/version.sh
@@ -6,7 +6,7 @@ cd ..
 if type git >/dev/null 2>/dev/null && [ -d .git ]; then
     version="$(git describe --dirty --tags --match 'v*')"
 else
-    version="$(awk '/#define KVZ_VERSION/ { print $3 }' src/global.h)"
+    version="v$(awk '/#define KVZ_VERSION/ { print $3 }' src/global.h)"
 fi
 
 printf '%s\n' "$version"


### PR DESCRIPTION
Fixes regression since 54f08f2 causing libkvazaar version checks to not
work (i.e. pkg-config)

Fixes https://github.com/jb-alvarado/media-autobuild_suite/issues/298