### PR TITLE
Include i386 & i486 for compiling intel asm.

### DIFF
--- a/src/global.h
+++ b/src/global.h
@@ -253,7 +253,7 @@ typedef enum { COLOR_Y = 0, COLOR_U, COLOR_V } color_t;
 
 
 // Hardware data (abstraction of defines). Extend for other compilers
-#if defined(_M_IX86) || defined(__i586__) || defined(__i686__) || defined(_M_X64) || defined(_M_AMD64) || defined(__amd64__) || defined(__x86_64__)
+#if defined(_M_IX86) || defined(__i386__) || defined(__i486__) || defined(__i586__) || defined(__i686__) || defined(_M_X64) || defined(_M_AMD64) || defined(__amd64__) || defined(__x86_64__)
 #  define COMPILE_INTEL 1
 #else
 #  define COMPILE_INTEL 0


### PR DESCRIPTION
x86_64-pc-linux-gnu-gcc -m32 that I use for building 32bits libraries on amd64 defines only __i386__.