### PR TITLE
Unbreak `make check` on FreeBSD

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,17 +1,17 @@
 
 TESTS = $(check_PROGRAMS) \
-    test_external_symbols.bash \
-    test_gop.bash \
-    test_interlace.bash \
-    test_intra.bash \
-    test_invalid_input.bash \
-    test_mv_constraint.bash \
-    test_owf_wpp_tiles.bash \
-    test_rate_control.bash \
-    test_slices.bash \
-    test_smp.bash \
-    test_tools.bash \
-    test_weird_shapes.bash
+    test_external_symbols.sh \
+    test_gop.sh \
+    test_interlace.sh \
+    test_intra.sh \
+    test_invalid_input.sh \
+    test_mv_constraint.sh \
+    test_owf_wpp_tiles.sh \
+    test_rate_control.sh \
+    test_slices.sh \
+    test_smp.sh \
+    test_tools.sh \
+    test_weird_shapes.sh
 
 check_PROGRAMS = kvazaar_tests
 

--- a/tests/test_external_symbols.sh
+++ b/tests/test_external_symbols.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
 # Check for external symbols without kvz_ prefix.
 
-set -euo pipefail
+set -eu${BASH+o pipefail}
 
 if nm -go --defined-only ../src/.libs/libkvazaar.a | grep -v ' kvz_'; then
     printf '%s\n' 'Only symbols prefixed with "kvz_" should be exported from libkvazaar.'

--- a/tests/test_gop.sh
+++ b/tests/test_gop.sh
@@ -3,7 +3,7 @@
 # Test GOP, with and without OWF.
 
 set -eu
-. util.sh
+. "${0%/*}/util.sh"
 
 common_args='-p0 --threads=2 --wpp --rd=0 --no-rdoq --no-deblock --no-sao --no-signhide --subme=0 --pu-depth-inter=1-3 --pu-depth-intra=2-3'
 valgrind_test 264x130 10 $common_args --gop=8 -p0 --owf=1

--- a/tests/test_gop.sh
+++ b/tests/test_gop.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
 # Test GOP, with and without OWF.
 
 set -eu
-source util.bash
+. util.sh
 
 common_args='-p0 --threads=2 --wpp --rd=0 --no-rdoq --no-deblock --no-sao --no-signhide --subme=0 --pu-depth-inter=1-3 --pu-depth-intra=2-3'
 valgrind_test 264x130 10 $common_args --gop=8 -p0 --owf=1

--- a/tests/test_interlace.sh
+++ b/tests/test_interlace.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 set -eu
-. util.sh
+. "${0%/*}/util.sh"
 
 valgrind_test 264x130 10 --source-scan-type=tff -p0 --preset=ultrafast --threads=2 --owf=1 --wpp

--- a/tests/test_interlace.sh
+++ b/tests/test_interlace.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
-source util.bash
+. util.sh
 
 valgrind_test 264x130 10 --source-scan-type=tff -p0 --preset=ultrafast --threads=2 --owf=1 --wpp

--- a/tests/test_intra.sh
+++ b/tests/test_intra.sh
@@ -4,7 +4,7 @@
 
 set -eu
 
-. util.sh
+. "${0%/*}/util.sh"
 
 common_args='264x130 10 -p1 --threads=2 --owf=1 --no-rdoq --no-deblock --no-sao --no-signhide'
 valgrind_test $common_args --rd=1

--- a/tests/test_intra.sh
+++ b/tests/test_intra.sh
@@ -1,10 +1,10 @@
-#!/bin/bash
+#!/bin/sh
 
 # Test all-intra coding.
 
 set -eu
 
-source util.bash
+. util.sh
 
 common_args='264x130 10 -p1 --threads=2 --owf=1 --no-rdoq --no-deblock --no-sao --no-signhide'
 valgrind_test $common_args --rd=1

--- a/tests/test_invalid_input.sh
+++ b/tests/test_invalid_input.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
 # Test trying to use invalid input dimensions.
 
 set -eu
-source util.bash
+. util.sh
 
 encode_test 1x65 1 1

--- a/tests/test_invalid_input.sh
+++ b/tests/test_invalid_input.sh
@@ -3,6 +3,6 @@
 # Test trying to use invalid input dimensions.
 
 set -eu
-. util.sh
+. "${0%/*}/util.sh"
 
 encode_test 1x65 1 1

--- a/tests/test_mv_constraint.sh
+++ b/tests/test_mv_constraint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 set -eu
-. util.sh
+. "${0%/*}/util.sh"
 
 valgrind_test 264x130 10 --threads=2 --owf=1 --preset=ultrafast --pu-depth-inter=0-3 --mv-constraint=frametilemargin
 valgrind_test 264x130 10 --threads=2 --owf=1 --preset=ultrafast --subme=4 --mv-constraint=frametilemargin

--- a/tests/test_mv_constraint.sh
+++ b/tests/test_mv_constraint.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
-source util.bash
+. util.sh
 
 valgrind_test 264x130 10 --threads=2 --owf=1 --preset=ultrafast --pu-depth-inter=0-3 --mv-constraint=frametilemargin
 valgrind_test 264x130 10 --threads=2 --owf=1 --preset=ultrafast --subme=4 --mv-constraint=frametilemargin

--- a/tests/test_owf_wpp_tiles.sh
+++ b/tests/test_owf_wpp_tiles.sh
@@ -5,7 +5,7 @@
 # tried.
 
 set -eu
-. util.sh
+. "${0%/*}/util.sh"
 
 common_args='-p4 --rd=0 --no-rdoq --no-deblock --no-sao --no-signhide --subme=0 --pu-depth-inter=1-3 --pu-depth-intra=2-3'
 valgrind_test 264x130 10 $common_args -r1 --owf=1 --threads=0 --no-wpp

--- a/tests/test_owf_wpp_tiles.sh
+++ b/tests/test_owf_wpp_tiles.sh
@@ -1,11 +1,11 @@
-#!/bin/bash
+#!/bin/sh
 
 # Test OWF, WPP and tiles. There is lots of separate branches of code
 # related to owf == 0 and owf != 0, which is why all permutations are
 # tried.
 
 set -eu
-source util.bash
+. util.sh
 
 common_args='-p4 --rd=0 --no-rdoq --no-deblock --no-sao --no-signhide --subme=0 --pu-depth-inter=1-3 --pu-depth-intra=2-3'
 valgrind_test 264x130 10 $common_args -r1 --owf=1 --threads=0 --no-wpp

--- a/tests/test_rate_control.sh
+++ b/tests/test_rate_control.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 set -eu
-. util.sh
+. "${0%/*}/util.sh"
 
 valgrind_test 264x130 10 --bitrate=500000 -p0 -r1 --owf=1 --threads=2 --rd=0 --no-rdoq --no-deblock --no-sao --no-signhide --subme=0 --pu-depth-inter=1-3 --pu-depth-intra=2-3

--- a/tests/test_rate_control.sh
+++ b/tests/test_rate_control.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
-source util.bash
+. util.sh
 
 valgrind_test 264x130 10 --bitrate=500000 -p0 -r1 --owf=1 --threads=2 --rd=0 --no-rdoq --no-deblock --no-sao --no-signhide --subme=0 --pu-depth-inter=1-3 --pu-depth-intra=2-3

--- a/tests/test_slices.sh
+++ b/tests/test_slices.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
-source util.bash
+. util.sh
 
 valgrind_test 512x256 10 --threads=2 --owf=1 --preset=ultrafast --tiles=2x2 --slices=tiles
 valgrind_test 264x130 10 --threads=2 --owf=1 --preset=ultrafast --slices=wpp

--- a/tests/test_slices.sh
+++ b/tests/test_slices.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 set -eu
-. util.sh
+. "${0%/*}/util.sh"
 
 valgrind_test 512x256 10 --threads=2 --owf=1 --preset=ultrafast --tiles=2x2 --slices=tiles
 valgrind_test 264x130 10 --threads=2 --owf=1 --preset=ultrafast --slices=wpp

--- a/tests/test_smp.sh
+++ b/tests/test_smp.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
 # Test SMP and AMP blocks.
 
 set -eu
-source util.bash
+. util.sh
 
 valgrind_test 264x130 4 --threads=2 --owf=1 --wpp --smp
 valgrind_test 264x130 4 --threads=2 --owf=1 --wpp --amp

--- a/tests/test_smp.sh
+++ b/tests/test_smp.sh
@@ -3,7 +3,7 @@
 # Test SMP and AMP blocks.
 
 set -eu
-. util.sh
+. "${0%/*}/util.sh"
 
 valgrind_test 264x130 4 --threads=2 --owf=1 --wpp --smp
 valgrind_test 264x130 4 --threads=2 --owf=1 --wpp --amp

--- a/tests/test_tools.sh
+++ b/tests/test_tools.sh
@@ -3,7 +3,7 @@
 # Test RDOQ, SAO, deblock and signhide and subme.
 
 set -eu
-. util.sh
+. "${0%/*}/util.sh"
 
 common_args='264x130 10 -p0 -r1 --threads=2 --wpp --owf=1 --rd=0'
 

--- a/tests/test_tools.sh
+++ b/tests/test_tools.sh
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
 # Test RDOQ, SAO, deblock and signhide and subme.
 
 set -eu
-source util.bash
+. util.sh
 
 common_args='264x130 10 -p0 -r1 --threads=2 --wpp --owf=1 --rd=0'
 

--- a/tests/test_weird_shapes.sh
+++ b/tests/test_weird_shapes.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 set -eu
-. util.sh
+. "${0%/*}/util.sh"
 
 valgrind_test  16x16  10 --threads=2 --owf=1 --preset=veryslow
 valgrind_test 256x16  10 --threads=2 --owf=1 --preset=veryslow

--- a/tests/test_weird_shapes.sh
+++ b/tests/test_weird_shapes.sh
@@ -1,7 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
 set -eu
-source util.bash
+. util.sh
 
 valgrind_test  16x16  10 --threads=2 --owf=1 --preset=veryslow
 valgrind_test 256x16  10 --threads=2 --owf=1 --preset=veryslow

--- a/tests/util.sh
+++ b/tests/util.sh
@@ -5,11 +5,11 @@
 set -eu${BASH+o pipefail}
 
 # Temporary files for encoder input and output.
-yuvfile="$(mktemp --tmpdir tmp.XXXXXXXXXX.yuv)"
-hevcfile="$(mktemp --tmpdir tmp.XXXXXXXXXX.hevc)"
+yuvfile="$(mktemp)"
+hevcfile="$(mktemp)"
 
 cleanup() {
-    rm -rf ${yuvfile} ${hevcfile}
+    rm -rf "${yuvfile}" "${hevcfile}"
 }
 trap cleanup EXIT
 
@@ -22,7 +22,7 @@ prepare() {
     cleanup
     print_and_run \
         ffmpeg -f lavfi -i "mandelbrot=size=${1}" \
-            -vframes "${2}" -pix_fmt yuv420p \
+            -vframes "${2}" -pix_fmt yuv420p -f yuv4mpegpipe \
             "${yuvfile}"
 }
 

--- a/tests/util.sh
+++ b/tests/util.sh
@@ -1,8 +1,8 @@
-#!/bin/bash
+#!/bin/sh
 
 # Helper functions for test scripts.
 
-set -euo pipefail
+set -eu${BASH+o pipefail}
 
 # Temporary files for encoder input and output.
 yuvfile="$(mktemp --tmpdir tmp.XXXXXXXXXX.yuv)"
@@ -61,5 +61,5 @@ encode_test() {
             ../src/kvazaar -i "${yuvfile}" "--input-res=${dimensions}" -o "${hevcfile}" "$@"
     actual_status="$?"
     set -e
-    [[ ${actual_status} = ${expected_status} ]]
+    [ ${actual_status} -eq ${expected_status} ]
 }


### PR DESCRIPTION
Regressed by 674af752a2bd:
- `/bin/bash` is distribution-specific, never happens on BSDs
- bash may not be installed or emulated by zsh
- `set -o pipefail` is bash-specific, the rest runs fine on zsh or (d)ash
- `mktemp --tmpdir` is GNU-specific but unrelated to bash
