### PR TITLE
Check also for libcryptopp.pc in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -68,7 +68,10 @@ AS_IF([test "x$with_cryptopp" = "xyes"],
         [AC_DEFINE([KVZ_SEL_ENCRYPTION], [1], [With cryptopp])],
         [PKG_CHECK_MODULES([cryptopp], [libcrypto++],
             [AC_DEFINE([KVZ_SEL_ENCRYPTION], [1], [With cryptopp])],
-            [AC_MSG_ERROR([neither cryptopp nor libcrypto++ found with pkg-config])]
+            [PKG_CHECK_MODULES([cryptopp], [libcryptopp],
+                [AC_DEFINE([KVZ_SEL_ENCRYPTION], [1], [With cryptopp])],
+                [AC_MSG_ERROR([neither cryptopp, libcrypto++ nor libcryptopp found with pkg-config])]
+            )]
         )]
     )]
 )


### PR DESCRIPTION
cryptopp in version 6.1.0 added a pkg config file which is named libcryptopp.pc
so search also for this name in addition to cryptopp and libcrypto++

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>