### PR TITLE
Clean up macOS includes in src/strategyselector.c

### DIFF
--- a/src/strategyselector.c
+++ b/src/strategyselector.c
@@ -26,9 +26,6 @@
 
 #ifdef _WIN32
 #include <windows.h>
-#elif MACOS
-#include <sys/param.h>
-#include <sys/sysctl.h>
 #else
 #include <unistd.h>
 #endif
@@ -423,7 +420,9 @@ static int altivec_available(void)
 #  elif defined(__APPLE__) || defined(__NetBSD__) || defined(__OpenBSD__)
 #include <sys/param.h>
 #include <sys/sysctl.h>
+#ifndef __APPLE__
 #include <machine/cpu.h>
+#endif
 
 static int altivec_available(void)
 {


### PR DESCRIPTION
Blind follow up to #205. `MACOS` [isn't defined](https://github.com/llvm-mirror/clang/blob/ddb77a4e35a6/lib/Basic/Targets/OSTargets.cpp) on... macOS. 31c5ff0f160e probably tried to use `hw.ncpu` before finding more portable `_SC_NPROCESSORS_ONLN`.