### PR TITLE
x86 asm: mark stack as non-executable

### DIFF
--- a/src/strategies/x86_asm/x86inc.asm
+++ b/src/strategies/x86_asm/x86inc.asm
@@ -1454,3 +1454,13 @@ FMA4_INSTR fnmsubss, fnmsub132ss, fnmsub213ss, fnmsub231ss
 %endif
 %endmacro
 %endif
+
+%ifidn __OUTPUT_FORMAT__,elf
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+%ifidn __OUTPUT_FORMAT__,elf32
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif
+%ifidn __OUTPUT_FORMAT__,elf64
+section .note.GNU-stack noalloc noexec nowrite progbits
+%endif


### PR DESCRIPTION
Gentoo's `scanelf` QA tool detects writable/executable stack
of assembly-writtent files as:

```
$ scanelf -qRa  .
 0644 LE !WX --- ---     ./src/strategies/x86_asm/.libs/picture-x86-asm-sad.o
 0644 LE !WX --- ---     ./src/strategies/x86_asm/.libs/picture-x86-asm-satd.o
 0644 LE !WX --- ---     ./src/strategies/x86_asm/picture-x86-asm-sad.o
 0644 LE !WX --- ---     ./src/strategies/x86_asm/picture-x86-asm-satd.o
```

Normally C compiler emits non-executable stack marking (or GNU assembler
via `-Wa,--noexecstack`).

The change adds non-executable stack marking for yasm-based assmbly files.

https://wiki.gentoo.org/wiki/Hardened/GNU_stack_quickstart has more details.

Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>