### PR TITLE
Enable -mpopcnt and -mlzcnt on AVX2

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -226,7 +226,7 @@ endif #HAVE_PPC
 if HAVE_X86
 
 if HAVE_AVX2_GCC
-libavx2_la_CFLAGS = -mavx2 -mbmi -mabm -mbmi2
+libavx2_la_CFLAGS = -mavx2 -mbmi -mabm -mpopcnt -mlzcnt -mbmi2
 endif
 if HAVE_AVX2_CLANG
 libavx2_la_CFLAGS = -mavx2 -mbmi -mpopcnt -mlzcnt -mbmi2


### PR DESCRIPTION
When -mpopcnt or -mlzcnt are explicitly enable or disabled (when using -march=native for example), kvazaar builds fail on older CPUs without support for these flags (see https://github.com/ultravideo/kvazaar/issues/228 and https://bugs.gentoo.org/739776 ).

Ensuring these flags are on as done with the rest of AVX2 flags solves the compilation issues, although it may be a better approach to provide a configuration option so that only the specific version matching the build system supported flags is created in such cases.