### PR TITLE
Remove additional apt-get clean in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,6 @@ ADD . kvazaar
 # data in the image.
 RUN apt-get update \
     && apt-get install -y $REQUIRED_PACKAGES \
-    && apt-get clean \
     && cd kvazaar \
     && ./autogen.sh \
     && ./configure --disable-shared \
@@ -35,7 +34,6 @@ RUN apt-get update \
     && make install \
     && AUTOINSTALLED_PACKAGES=`apt-mark showauto` \
     && apt-get remove --purge --force-yes -y $REQUIRED_PACKAGES $AUTOINSTALLED_PACKAGES \
-    && apt-get clean autoclean \
     && apt-get autoremove -y \
     && rm -rf /var/lib/{apt,dpkg,cache,log}/
 


### PR DESCRIPTION
Reference:

- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get

> Official Debian and Ubuntu images automatically run `apt-get clean`,
> so explicit invocation is not required.