### PR TITLE
build: fix automake warning

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,7 +54,7 @@ libkvazaar_la_SOURCES = \
 	cfg.c \
 	cfg.h \
 	constraint.c \
-	constraint.h \ 
+	constraint.h \
 	context.c \
 	context.h \
 	cu.c \


### PR DESCRIPTION
Fixes a nuisance warning from `autogen.sh`:

```
src/Makefile.am:57: warning: whitespace following trailing backslash
```
