### PR TITLE
encoder: remove bitdepth

### DIFF
--- a/src/encmain.c
+++ b/src/encmain.c
@@ -211,7 +211,7 @@ static void* input_read_thread(void* in_args)
                                     args->opts->config->width,
                                     args->opts->config->height,
                                     args->encoder->cfg.input_bitdepth,
-                                    args->encoder->bitdepth,
+                                    KVZ_BIT_DEPTH,
                                     frame_in, args->opts->config->file_format);
     if (!read_success) {
       // reading failed
@@ -230,7 +230,7 @@ static void* input_read_thread(void* in_args)
                                           args->opts->config->width,
                                           args->opts->config->height,
                                           args->encoder->cfg.input_bitdepth,
-                                          args->encoder->bitdepth,
+                                          KVZ_BIT_DEPTH,
                                           frame_in, args->opts->config->file_format);
           if (!read_success) {
             fprintf(stderr, "Could not re-open input file, shutting down!\n");

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -238,8 +238,6 @@ encoder_control_t* kvz_encoder_control_init(const kvz_config *const cfg)
     goto init_failed;
   }
 
-  encoder->bitdepth = KVZ_BIT_DEPTH;
-
   encoder->chroma_format = KVZ_FORMAT2CSP(encoder->cfg.input_format);
 
   // Interlacing
@@ -301,7 +299,7 @@ encoder_control_t* kvz_encoder_control_init(const kvz_config *const cfg)
     }
   }
 
-  kvz_scalinglist_process(&encoder->scaling_list, encoder->bitdepth);
+  kvz_scalinglist_process(&encoder->scaling_list, KVZ_BIT_DEPTH);
 
   kvz_encoder_control_input_init(encoder, encoder->cfg.width, encoder->cfg.height);
 

--- a/src/encoder.h
+++ b/src/encoder.h
@@ -79,7 +79,6 @@ typedef struct encoder_control_t
     int range;
   } me;
 
-  int8_t bitdepth;
   enum kvz_chroma_format chroma_format;
 
   /* VUI */

--- a/src/encoder_state-bitstream.c
+++ b/src/encoder_state-bitstream.c
@@ -76,7 +76,7 @@ static void encoder_state_write_bitstream_PTL(bitstream_t *stream,
   WRITE_U(stream, 0, 2, "general_profile_space");
   WRITE_U(stream, state->encoder_control->cfg.high_tier, 1, "general_tier_flag");
   // Main Profile == 1,  Main 10 profile == 2
-  WRITE_U(stream, (state->encoder_control->bitdepth == 8) ? 1 : 2, 5, "general_profile_idc");
+  WRITE_U(stream, (KVZ_BIT_DEPTH == 8) ? 1 : 2, 5, "general_profile_idc");
   /* Compatibility flags should be set at general_profile_idc
    *  (so with general_profile_idc = 1, compatibility_flag[1] should be 1)
    * According to specification, when compatibility_flag[1] is set,
@@ -410,8 +410,8 @@ static void encoder_state_write_bitstream_seq_parameter_set(bitstream_t* stream,
   //IF window flag
   //END IF
 
-  WRITE_UE(stream, encoder->bitdepth-8, "bit_depth_luma_minus8");
-  WRITE_UE(stream, encoder->bitdepth-8, "bit_depth_chroma_minus8");
+  WRITE_UE(stream, KVZ_BIT_DEPTH-8, "bit_depth_luma_minus8");
+  WRITE_UE(stream, KVZ_BIT_DEPTH-8, "bit_depth_chroma_minus8");
   WRITE_UE(stream, encoder->poc_lsb_bits - 4, "log2_max_pic_order_cnt_lsb_minus4");
 
   WRITE_U(stream, 0, 1, "sps_sub_layer_ordering_info_present_flag");
@@ -972,7 +972,7 @@ static void add_checksum(encoder_state_t * const state)
   switch (state->encoder_control->cfg.hash)
   {
   case KVZ_HASH_CHECKSUM:
-    kvz_image_checksum(frame->rec, checksum, state->encoder_control->bitdepth);
+    kvz_image_checksum(frame->rec, checksum, KVZ_BIT_DEPTH);
 
     sei_write_payload_size(stream, 1 + num_colors * 4);
     WRITE_U(stream, 2, 8, "hash_type");  // 2 = checksum
@@ -988,7 +988,7 @@ static void add_checksum(encoder_state_t * const state)
     break;
 
   case KVZ_HASH_MD5:
-    kvz_image_md5(frame->rec, checksum, state->encoder_control->bitdepth);
+    kvz_image_md5(frame->rec, checksum, KVZ_BIT_DEPTH);
 
     sei_write_payload_size(stream, 1 + num_colors * 16);
     WRITE_U(stream, 0, 8, "hash_type");  // 0 = md5

--- a/src/filter.c
+++ b/src/filter.c
@@ -144,16 +144,16 @@ static INLINE int kvz_filter_deblock_luma_weak(
   } else {
     int32_t tc2 = tc >> 1;
     delta = CLIP(-tc, tc, delta);
-    line[3] = CLIP(0, (1 << encoder->bitdepth) - 1, (m3 + delta));
-    line[4] = CLIP(0, (1 << encoder->bitdepth) - 1, (m4 - delta));
+    line[3] = CLIP(0, (1 << KVZ_BIT_DEPTH) - 1, (m3 + delta));
+    line[4] = CLIP(0, (1 << KVZ_BIT_DEPTH) - 1, (m4 - delta));
 
     if (p_2nd) {
       int32_t delta1 = CLIP(-tc2, tc2, (((m1 + m3 + 1) >> 1) - m2 + delta) >> 1);
-      line[2] = CLIP(0, (1 << encoder->bitdepth) - 1, m2 + delta1);
+      line[2] = CLIP(0, (1 << KVZ_BIT_DEPTH) - 1, m2 + delta1);
     }
     if (q_2nd) {
       int32_t delta2 = CLIP(-tc2, tc2, (((m6 + m4 + 1) >> 1) - m5 - delta) >> 1);
-      line[5] = CLIP(0, (1 << encoder->bitdepth) - 1, m5 + delta2);
+      line[5] = CLIP(0, (1 << KVZ_BIT_DEPTH) - 1, m5 + delta2);
     }
     
     if (p_2nd || q_2nd) {
@@ -182,10 +182,10 @@ static INLINE void kvz_filter_deblock_chroma(const encoder_control_t * const enc
 
   delta = CLIP(-tc,tc, (((m4 - m3) * 4) + m2 - m5 + 4 ) >> 3);
   if(!part_P_nofilter) {
-    src[-offset] = CLIP(0, (1 << encoder->bitdepth) - 1, m3 + delta);
+    src[-offset] = CLIP(0, (1 << KVZ_BIT_DEPTH) - 1, m3 + delta);
   }
   if(!part_Q_nofilter) {
-    src[0] = CLIP(0, (1 << encoder->bitdepth) - 1, m4 - delta);
+    src[0] = CLIP(0, (1 << KVZ_BIT_DEPTH) - 1, m4 - delta);
   }
 }
 
@@ -370,7 +370,7 @@ static void filter_deblock_edge_luma(encoder_state_t * const state,
     const int32_t qp = get_qp_y_pred(state, x, y, dir);
 
     int8_t strength = 0;
-    int32_t bitdepth_scale  = 1 << (encoder->bitdepth - 8);
+    int32_t bitdepth_scale  = 1 << (KVZ_BIT_DEPTH - 8);
     int32_t b_index         = CLIP(0, 51, qp + (beta_offset_div2 << 1));
     int32_t beta            = kvz_g_beta_table_8x8[b_index] * bitdepth_scale;
     int32_t side_threshold  = (beta + (beta >>1 )) >> 3;
@@ -587,7 +587,7 @@ static void filter_deblock_edge_chroma(encoder_state_t * const state,
 
     const int32_t luma_qp  = get_qp_y_pred(state, x << 1, y << 1, dir);
     int32_t QP             = kvz_g_chroma_scale[luma_qp];
-    int32_t bitdepth_scale = 1 << (encoder->bitdepth-8);
+    int32_t bitdepth_scale = 1 << (KVZ_BIT_DEPTH-8);
     int32_t TC_index       = CLIP(0, 51+2, (int32_t)(QP + 2*(strength-1) + (tc_offset_div2 << 1)));
     int32_t Tc             = kvz_g_tc_table_8x8[TC_index]*bitdepth_scale;
 

--- a/src/rdo.c
+++ b/src/rdo.c
@@ -537,14 +537,12 @@ void kvz_rdoq_sign_hiding(
     const coeff_t *const coeffs,
     coeff_t *const quant_coeffs)
 {
-  const encoder_control_t * const ctrl = state->encoder_control;
-
   int inv_quant = kvz_g_inv_quant_scales[qp_scaled % 6];
   // This somehow scales quant_delta into fractional bits. Instead of the bits
   // being multiplied by lambda, the residual is divided by it, or something
   // like that.
   const int64_t rd_factor = (inv_quant * inv_quant * (1 << (2 * (qp_scaled / 6)))
-                      / state->lambda / 16 / (1 << (2 * (ctrl->bitdepth - 8))) + 0.5);
+                      / state->lambda / 16 / (1 << (2 * (KVZ_BIT_DEPTH - 8))) + 0.5);
   const int last_cg = (last_pos - 1) >> LOG2_SCAN_SET_SIZE;
 
   for (int32_t cg_scan = last_cg; cg_scan >= 0; cg_scan--) {
@@ -677,12 +675,12 @@ void kvz_rdoq(encoder_state_t * const state, coeff_t *coef, coeff_t *dest_coeff,
   const encoder_control_t * const encoder = state->encoder_control;
   cabac_data_t * const cabac = &state->cabac;
   uint32_t log2_tr_size      = kvz_g_convert_to_bit[ width ] + 2;
-  int32_t  transform_shift   = MAX_TR_DYNAMIC_RANGE - encoder->bitdepth - log2_tr_size;  // Represents scaling through forward transform
+  int32_t  transform_shift   = MAX_TR_DYNAMIC_RANGE - KVZ_BIT_DEPTH - log2_tr_size;  // Represents scaling through forward transform
   uint16_t go_rice_param     = 0;
   uint32_t log2_block_size   = kvz_g_convert_to_bit[ width ] + 2;
   int32_t  scalinglist_type= (block_type == CU_INTRA ? 0 : 3) + (int8_t)("\0\3\1\2"[type]);
 
-  int32_t qp_scaled = kvz_get_scaled_qp(type, state->qp, (encoder->bitdepth - 8) * 6);
+  int32_t qp_scaled = kvz_get_scaled_qp(type, state->qp, (KVZ_BIT_DEPTH - 8) * 6);
   
   int32_t q_bits = QUANT_SHIFT + qp_scaled/6 + transform_shift;
 

--- a/src/sao.c
+++ b/src/sao.c
@@ -180,8 +180,8 @@ static double sao_mode_bits_band(const encoder_state_t * const state,
 void kvz_calc_sao_offset_array(const encoder_control_t * const encoder, const sao_info_t *sao, int *offset, color_t color_i)
 {
   int32_t val;
-  const int32_t values = (1<<encoder->bitdepth);
-  const int32_t shift = encoder->bitdepth-5;
+  const int32_t values = (1<<KVZ_BIT_DEPTH);
+  const int32_t shift = KVZ_BIT_DEPTH-5;
   const int32_t band_pos = (color_i == COLOR_V) ? 1 : 0;
   const int32_t cur_bp   = sao->band_position[band_pos];
 
@@ -270,7 +270,7 @@ static void calc_sao_bands(const encoder_state_t * const state, const kvz_pixel 
                            int sao_bands[2][32])
 {
   int y, x;
-  int shift = state->encoder_control->bitdepth-5;
+  int shift = KVZ_BIT_DEPTH-5;
 
   //Loop pixels and take top 5 bits to classify different bands
   for (y = 0; y < block_height; ++y) {

--- a/src/strategies/avx2/quant-avx2.c
+++ b/src/strategies/avx2/quant-avx2.c
@@ -365,11 +365,11 @@ void kvz_quant_avx2(const encoder_state_t * const state, const coeff_t * __restr
   const uint32_t log2_block_size = kvz_g_convert_to_bit[width] + 2;
   const uint32_t * const  __restrict scan = kvz_g_sig_last_scan[scan_idx][log2_block_size - 1];
 
-  int32_t qp_scaled = kvz_get_scaled_qp(type, state->qp, (encoder->bitdepth - 8) * 6);
+  int32_t qp_scaled = kvz_get_scaled_qp(type, state->qp, (KVZ_BIT_DEPTH - 8) * 6);
   const uint32_t log2_tr_size = kvz_g_convert_to_bit[width] + 2;
   const int32_t scalinglist_type = (block_type == CU_INTRA ? 0 : 3) + (int8_t)("\0\3\1\2"[type]);
   const int32_t *quant_coeff = encoder->scaling_list.quant_coeff[log2_tr_size - 2][scalinglist_type][qp_scaled % 6];
-  const int32_t transform_shift = MAX_TR_DYNAMIC_RANGE - encoder->bitdepth - log2_tr_size; //!< Represents scaling through forward transform
+  const int32_t transform_shift = MAX_TR_DYNAMIC_RANGE - KVZ_BIT_DEPTH- log2_tr_size; //!< Represents scaling through forward transform
   const int32_t q_bits = QUANT_SHIFT + qp_scaled / 6 + transform_shift;
   const int32_t add = ((state->frame->slicetype == KVZ_SLICE_I) ? 171 : 85) << (q_bits - 9);
   const int32_t q_bits8 = q_bits - 8;
@@ -728,9 +728,9 @@ void kvz_dequant_avx2(const encoder_state_t * const state, coeff_t *q_coef, coef
   const encoder_control_t * const encoder = state->encoder_control;
   int32_t shift,add,coeff_q;
   int32_t n;
-  int32_t transform_shift = 15 - encoder->bitdepth - (kvz_g_convert_to_bit[ width ] + 2);
+  int32_t transform_shift = 15 - KVZ_BIT_DEPTH - (kvz_g_convert_to_bit[ width ] + 2);
 
-  int32_t qp_scaled = kvz_get_scaled_qp(type, state->qp, (encoder->bitdepth-8)*6);
+  int32_t qp_scaled = kvz_get_scaled_qp(type, state->qp, (KVZ_BIT_DEPTH - 8)*6);
 
   shift = 20 - QUANT_SHIFT - transform_shift;
 

--- a/src/strategies/generic/quant-generic.c
+++ b/src/strategies/generic/quant-generic.c
@@ -54,11 +54,11 @@ void kvz_quant_generic(const encoder_state_t * const state, coeff_t *coef, coeff
   const uint32_t log2_block_size = kvz_g_convert_to_bit[width] + 2;
   const uint32_t * const scan = kvz_g_sig_last_scan[scan_idx][log2_block_size - 1];
 
-  int32_t qp_scaled = kvz_get_scaled_qp(type, state->qp, (encoder->bitdepth - 8) * 6);
+  int32_t qp_scaled = kvz_get_scaled_qp(type, state->qp, (KVZ_BIT_DEPTH - 8) * 6);
   const uint32_t log2_tr_size = kvz_g_convert_to_bit[width] + 2;
   const int32_t scalinglist_type = (block_type == CU_INTRA ? 0 : 3) + (int8_t)("\0\3\1\2"[type]);
   const int32_t *quant_coeff = encoder->scaling_list.quant_coeff[log2_tr_size - 2][scalinglist_type][qp_scaled % 6];
-  const int32_t transform_shift = MAX_TR_DYNAMIC_RANGE - encoder->bitdepth - log2_tr_size; //!< Represents scaling through forward transform
+  const int32_t transform_shift = MAX_TR_DYNAMIC_RANGE - KVZ_BIT_DEPTH - log2_tr_size; //!< Represents scaling through forward transform
   const int32_t q_bits = QUANT_SHIFT + qp_scaled / 6 + transform_shift;
   const int32_t add = ((state->frame->slicetype == KVZ_SLICE_I) ? 171 : 85) << (q_bits - 9);
   const int32_t q_bits8 = q_bits - 8;
@@ -300,9 +300,9 @@ void kvz_dequant_generic(const encoder_state_t * const state, coeff_t *q_coef, c
   const encoder_control_t * const encoder = state->encoder_control;
   int32_t shift,add,coeff_q;
   int32_t n;
-  int32_t transform_shift = 15 - encoder->bitdepth - (kvz_g_convert_to_bit[ width ] + 2);
+  int32_t transform_shift = 15 - KVZ_BIT_DEPTH - (kvz_g_convert_to_bit[ width ] + 2);
 
-  int32_t qp_scaled = kvz_get_scaled_qp(type, state->qp, (encoder->bitdepth-8)*6);
+  int32_t qp_scaled = kvz_get_scaled_qp(type, state->qp, (KVZ_BIT_DEPTH-8)*6);
 
   shift = 20 - QUANT_SHIFT - transform_shift;
 

--- a/src/strategies/generic/sao_shared_generics.h
+++ b/src/strategies/generic/sao_shared_generics.h
@@ -96,7 +96,7 @@ static int sao_band_ddistortion_generic(const encoder_state_t * const state,
                                         const int sao_bands[4])
 {
   int y, x;
-  int shift = state->encoder_control->bitdepth-5;
+  int shift = KVZ_BIT_DEPTH - 5;
   int sum = 0;
   for (y = 0; y < block_height; ++y) {
     for (x = 0; x < block_width; ++x) {

--- a/src/transform.c
+++ b/src/transform.c
@@ -163,7 +163,7 @@ int32_t kvz_get_scaled_qp(int8_t type, int8_t qp, int8_t qp_offset)
 void kvz_transformskip(const encoder_control_t * const encoder, int16_t *block,int16_t *coeff, int8_t block_size)
 {
   uint32_t log2_tr_size =  kvz_g_convert_to_bit[block_size] + 2;
-  int32_t  shift = MAX_TR_DYNAMIC_RANGE - encoder->bitdepth - log2_tr_size;
+  int32_t  shift = MAX_TR_DYNAMIC_RANGE - KVZ_BIT_DEPTH - log2_tr_size;
   int32_t  j,k;
   for (j = 0; j < block_size; j++) {
     for(k = 0; k < block_size; k ++) {
@@ -182,7 +182,7 @@ void kvz_transformskip(const encoder_control_t * const encoder, int16_t *block,i
 void kvz_itransformskip(const encoder_control_t * const encoder, int16_t *block,int16_t *coeff, int8_t block_size)
 {
   uint32_t log2_tr_size =  kvz_g_convert_to_bit[block_size] + 2;
-  int32_t  shift = MAX_TR_DYNAMIC_RANGE - encoder->bitdepth - log2_tr_size;
+  int32_t  shift = MAX_TR_DYNAMIC_RANGE - KVZ_BIT_DEPTH - log2_tr_size;
   int32_t  j,k;
   int32_t offset;
   offset = (1 << (shift -1)); // For rounding
@@ -207,7 +207,7 @@ void kvz_transform2d(const encoder_control_t * const encoder,
                      cu_type_t type)
 {
   dct_func *dct_func = kvz_get_dct_func(block_size, color, type);
-  dct_func(encoder->bitdepth, block, coeff);
+  dct_func(KVZ_BIT_DEPTH, block, coeff);
 }
 
 void kvz_itransform2d(const encoder_control_t * const encoder,
@@ -218,7 +218,7 @@ void kvz_itransform2d(const encoder_control_t * const encoder,
                       cu_type_t type)
 {
   dct_func *idct_func = kvz_get_idct_func(block_size, color, type);
-  idct_func(encoder->bitdepth, coeff, block);
+  idct_func(KVZ_BIT_DEPTH, coeff, block);
 }
 
 /**


### PR DESCRIPTION
Removes the `bitdepth` field from the `encoder_control_t` structure. 

This field is always equals to `KVZ_BIT_DEPTH`.

I tried encoding pedestrian test sample, and the result was the same (bitwise identical) with current main and the modified code.