### PR TITLE
Update Dockerfile base image to Ubuntu 20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #
 
 # Use Ubuntu 18.04 as a base for now, it's around 88MB
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 MAINTAINER Marko Viitanen <fador@iki.fi>
 


### PR DESCRIPTION
Ubuntu 18.04 reached its end-of-life on May 31, 2023.