### PR TITLE
threads.h: fix for older macOS builds

### DIFF
--- a/src/threads.h
+++ b/src/threads.h
@@ -42,6 +42,10 @@
 
 #include <pthread.h>
 
+#ifdef __APPLE__
+#include <AvailabilityMacros.h>
+#endif
+
 #if defined(__GNUC__) && !defined(__MINGW32__) 
 #include <unistd.h> // IWYU pragma: export
 #include <time.h> // IWYU pragma: export
@@ -84,9 +88,9 @@
 
 #endif //__GNUC__
 
-#ifdef __APPLE__
-// POSIX semaphores are deprecated on Mac so we use Grand Central Dispatch
-// semaphores instead.
+#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > 1050 && !defined(__ppc__)
+// POSIX semaphores are deprecated on Mac so we use Grand Central Dispatch semaphores instead.
+// However GCD is supported only on 10.6+, and is not supported on any ppc, including 10.6 Rosetta.
 #include <dispatch/dispatch.h>
 typedef dispatch_semaphore_t kvz_sem_t;
 
@@ -113,7 +117,7 @@ static INLINE void kvz_sem_destroy(kvz_sem_t *sem)
 }
 
 #else
-// Use POSIX semaphores.
+// Use POSIX semaphores. This is also a fallback for old Darwin.
 #include <semaphore.h>
 
 typedef sem_t kvz_sem_t;


### PR DESCRIPTION
This fixes the build for older macOS, including PowerPC.

(For the record, the build does require a newer `gcc` – archaic Xcode ones fail at configure.)