### PR TITLE
Don't export MD5 byteReverse symbol on big-endian

### DIFF
--- a/src/extras/libmd5.c
+++ b/src/extras/libmd5.c
@@ -27,11 +27,11 @@ static void MD5Transform(uint32_t buf[4], uint32_t const in[16]);
 #ifndef __BIG_ENDIAN__
 # define byteReverse(buf, len)    /* Nothing */
 #else
-void byteReverse(uint32_t *buf, unsigned len);
+static void byteReverse(uint32_t *buf, unsigned len);
 /*
  * Note: this code is harmless on little-endian machines.
  */
-void byteReverse(uint32_t *buf, unsigned len)
+static void byteReverse(uint32_t *buf, unsigned len)
 {
   uint32_t t;
   do {


### PR DESCRIPTION
Otherwise this fails the test which checks that all exported symbols begin with kvz_ prefix.