### PR TITLE
Ignore "*get_pc_thunk.*" symbols in exported symbols test

### DIFF
--- a/tests/test_external_symbols.sh
+++ b/tests/test_external_symbols.sh
@@ -4,7 +4,7 @@
 
 set -eu${BASH+o pipefail}
 
-if nm -go --defined-only ../src/.libs/libkvazaar.a | grep -v ' kvz_'; then
+if nm -go --defined-only ../src/.libs/libkvazaar.a | grep -Ev ' (kvz_|__[a-z0-9]+(_|\.)get_pc_thunk\.)'; then
     printf '%s\n' 'Only symbols prefixed with "kvz_" should be exported from libkvazaar.'
     false
 fi


### PR DESCRIPTION
On i386 (32-bit x86) and sparc, gcc generates references to these functions which load the current PC into the specified register.  These references are then resolved at link-time.  Examples of what these symbols look like:

```
../src/.libs/libkvazaar.a:libkvazaar_la-cfg.o:00000000 T __x86.get_pc_thunk.ax
../src/.libs/libkvazaar.a:libkvazaar_la-cabac.o:0000000000000000 W __sparc_get_pc_thunk.l7
```

Since these are platform symbols inserted by the toolchain, ignore them. The regex is specified as tightly as possible, and based on a quick search these appear to be the only two platforms affected.