### PR TITLE
Fixed issue #394 - missing _mm256_storeu2_m128i macro

### DIFF
--- a/src/strategies/avx2/quant-avx2.c
+++ b/src/strategies/avx2/quant-avx2.c
@@ -54,6 +54,14 @@
 #include "transform.h"
 #include "fast_coeff_cost.h"
 
+// added missing header
+#define _mm256_storeu2_m128i(/* __m128i* */ hiaddr, /* __m128i* */ loaddr, /* __m256i */ a) \
+    do { __m256i _a = (a); \
+        _mm_storeu_si128((__m128i*)(loaddr), _mm256_castsi256_si128(_a)); \
+        _mm_storeu_si128((__m128i*)(hiaddr), _mm256_extractf128_si256(_a, 0x1)); \
+    } while (0)
+
+
 static INLINE int32_t hsum32_8x32i(__m256i src)
 {
   __m128i a = _mm256_extracti128_si256(src, 0);


### PR DESCRIPTION
Please look at the issue #394 for exact error while installing Kvazaar.
I tried installing it on Ubuntu 20.04 (2 different machines). I only tried this version `Kvazaar v2.3.0-24-ga909ddd2 2024-02-02`
Apparently, the macro `_mm256_storeu2_m128i` definition was missing from Intel Intrinsic header, so I added it directly in `kvazaar > src > strategies > avx2 > quant-avx2.c`.
After that I was able to successfully install and run kvazaar to encode an mp4 video to hevc format.