### PR TITLE
ax_pthread/clang: move -pthread to LIBS

### DIFF
--- a/m4/ax_pthread.m4
+++ b/m4/ax_pthread.m4
@@ -261,8 +261,8 @@ if test "x$ax_pthread_clang" = "xyes"; then
         # -pthread does define _REENTRANT, and while the Darwin headers
         # ignore this macro, third-party headers might not.)
 
-        PTHREAD_CFLAGS="-pthread"
-        PTHREAD_LIBS=
+        PTHREAD_CFLAGS=
+        PTHREAD_LIBS="-pthread"
 
         ax_pthread_ok=yes
 


### PR DESCRIPTION
clang also requires linking with -pthread to use pthreads. FFmpeg linking is broken otherwise due to undefined symbols.

Should remove the necessity of https://github.com/msys2/MINGW-packages/blob/5ed0594aee40d3df6437623c151b2a0e023634e1/mingw-w64-kvazaar/001-clang-pthread-fix.patch