### PR TITLE
fix android build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -235,14 +235,15 @@ else()
   # CYGWIN, MSYS, and MINGW seem to be needing this but in some cases 
   # it might be that the toolset is not properly set, so also use this
   # in cases where we are not sure that it is not needed
-  if((NOT MSVC AND NOT LINUX AND NOT APPLE) OR (CYGWIN OR MSYS OR MINGW))
+  if((NOT MSVC AND NOT LINUX AND NOT APPLE AND NOT ANDROID) OR (CYGWIN OR MSYS OR MINGW))
     set(CMAKE_C_FLAGS "-Wa,-muse-unaligned-vector-move ${CMAKE_C_FLAGS}")
   endif()
 
-  
-  set(THREADS_PREFER_PTHREAD_FLAG ON)
-  find_package(Threads REQUIRED)
-  target_link_libraries(kvazaar PUBLIC Threads::Threads)
+  if(NOT ANDROID)
+    set(THREADS_PREFER_PTHREAD_FLAG ON)
+    find_package(Threads REQUIRED)
+    target_link_libraries(kvazaar PUBLIC Threads::Threads)
+  endif()
 
   include(CheckLibraryExists)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,8 +25,11 @@ else()
   if(${CMAKE_SYSTEM_PROCESSOR} IN_LIST ALLOW_AVX2) 
     set_property( SOURCE ${TEST_SOURCES}  APPEND PROPERTY COMPILE_FLAGS "-mavx2 -mbmi -mpopcnt -mlzcnt -mbmi2" )
   endif()
-  find_package(Threads REQUIRED)
-  target_link_libraries(kvazaar_tests PUBLIC Threads::Threads)
+
+  if(NOT ANDROID)
+    find_package(Threads REQUIRED)
+    target_link_libraries(kvazaar_tests PUBLIC Threads::Threads)
+  endif()
 
   include(CheckLibraryExists)
 


### PR DESCRIPTION
This PR provides build fixes for Android.

The android build got broken in version 2.3.1.
In 2.3.0 it worked fine.

There are two build errors that are fixed with this PR for Android NDK builds:
1. Threads
```
CMake Error at /opt/homebrew/Cellar/cmake/3.25.1/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find Threads (missing: Threads_FOUND)
```
2. muse-unaligned-vector-move
```
sventrittler@Svens-MBP b % cmake --build .
[  1%] Building C object CMakeFiles/kvazaar.dir/src/bitstream.c.o
clang: error: unsupported argument '-muse-unaligned-vector-move' to option 'Wa,'
```

May android builds should be added to the CI some day.