### PR TITLE
fix ios build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ option(BUILD_TESTS "Build tests" ON)
 
 option(USE_CRYPTO "Use crypto library" OFF)
 
+option(BUILD_KVAZAAR_BINARY "Build kvazaar-bin" ON) # To build only the lib, useful for iOS-builds
+
 include(GNUInstallDirs) #Helps to define correct distro specific install directories
 set(DEFERRED "@")
 
@@ -213,18 +215,22 @@ if(MSVC)
   list(APPEND CLI_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/src/extras/getopt.c ${CMAKE_CURRENT_SOURCE_DIR}/src/threadwrapper/src/pthread.cpp ${CMAKE_CURRENT_SOURCE_DIR}/src/threadwrapper/src/semaphore.cpp)
 endif()
 
-add_executable(kvazaar-bin ${CLI_SOURCES})
+if(BUILD_KVAZAAR_BINARY)
+  add_executable(kvazaar-bin ${CLI_SOURCES})
 
-set_target_properties(kvazaar-bin PROPERTIES OUTPUT_NAME kvazaar)
-set_target_properties(kvazaar-bin PROPERTIES RUNTIME_OUTPUT_NAME kvazaar)
+  set_target_properties(kvazaar-bin PROPERTIES OUTPUT_NAME kvazaar)
+  set_target_properties(kvazaar-bin PROPERTIES RUNTIME_OUTPUT_NAME kvazaar)
 
-target_link_libraries(kvazaar-bin PUBLIC kvazaar)
+  target_link_libraries(kvazaar-bin PUBLIC kvazaar)
+endif()
 
 if(MSVC)
   target_include_directories(kvazaar PUBLIC src/threadwrapper/include)
   set_property( SOURCE ${LIB_SOURCES_STRATEGIES_AVX2} APPEND PROPERTY COMPILE_FLAGS "/arch:AVX2" )  
 else()
-  set_target_properties(kvazaar-bin PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src)
+  if(BUILD_KVAZAAR_BINARY)
+    set_target_properties(kvazaar-bin PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/src)
+  endif()
   set_target_properties(kvazaar PROPERTIES SOVERSION "7" VERSION "7.4.0")
   list(APPEND ALLOW_AVX2 "x86_64" "AMD64")
   if(${CMAKE_SYSTEM_PROCESSOR} IN_LIST ALLOW_AVX2) 
@@ -256,7 +262,9 @@ else()
   endif ()
 
   target_link_libraries(kvazaar PUBLIC ${EXTRA_LIBS})
-  target_link_libraries(kvazaar-bin PUBLIC ${EXTRA_LIBS} )
+  if(BUILD_KVAZAAR_BINARY)
+    target_link_libraries(kvazaar-bin PUBLIC ${EXTRA_LIBS} )
+  endif()
 endif()
 
 
@@ -308,7 +316,9 @@ source_group( "" FILES ${SOURCE_GROUP_TOPLEVEL})
 install(CODE "configure_file(\"${PROJECT_SOURCE_DIR}/src/kvazaar.pc.temp\" \"${PROJECT_SOURCE_DIR}/src/kvazaar.pc\" @ONLY)")
 
 install(FILES ${PROJECT_SOURCE_DIR}/src/kvazaar.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-install(TARGETS kvazaar-bin DESTINATION ${CMAKE_INSTALL_BINDIR})
+if(BUILD_KVAZAAR_BINARY)
+  install(TARGETS kvazaar-bin DESTINATION ${CMAKE_INSTALL_BINDIR})
+endif()
 install(TARGETS kvazaar
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
This PR fixes iOS builds.

On iOS it takes special care to build a executable, app bundle identifier are needed etc.

In a typical iOS build you only want to have the kvazaar lib to link with your app.

Because of that the option `-DBUILD_KVAZAAR_BINARY=OFF` is introduced to be able to build for iOS.

The build error looked like this:
```
cmake -G Xcode \
  -DBUILD_SHARED_LIBS=OFF \
  -DCMAKE_TOOLCHAIN_FILE=./ios.toolchain.cmake \
  -DPLATFORM=OS64 \
  -DBUILD_TESTS=OFF \
  -DCMAKE_BUILD_TYPE=Release \
  .. \
  && \
  xcodebuild -project kvazaar.xcodeproj \
                        -scheme install \
                        -configuration Release \
                        -quiet \
                        -allowProvisioningUpdates \
                        -destination generic/platform=iOS \
                        -derivedDataPath ./build \
                        build
. . .
-- Configuring done
-- Generating done
-- Build files have been written to: /Users/sventrittler/workspace/thridparty/kvazaar/x
note: Run script build phase 'Generate CMakeFiles/ZERO_CHECK' will be run during every build because the option to run the script phase "Based on dependency analysis" is unchecked. (in target 'ZERO_CHECK' from project 'kvazaar')
/Users/sventrittler/workspace/thridparty/kvazaar/x/kvazaar.xcodeproj: error: Bundle identifier is missing. kvazaar-bin doesn't have a bundle identifier. Add a value for PRODUCT_BUNDLE_IDENTIFIER in the build settings editor. (in target 'kvazaar-bin' from project 'kvazaar')
** BUILD FAILED **
```
