### PR TITLE
check whether API supports requested bit-depth

### DIFF
--- a/src/kvazaar.c
+++ b/src/kvazaar.c
@@ -420,5 +420,9 @@ static const kvz_api kvz_8bit_api = {
 
 const kvz_api * kvz_api_get(int bit_depth)
 {
+  if (bit_depth != KVZ_BIT_DEPTH) {
+    return NULL;
+  }
+
   return &kvz_8bit_api;
 }


### PR DESCRIPTION
This adds the check to `kvz_api_get(bit_depth)` whether the requested bit depth is supported.
See #399 
