### PR TITLE
Avoid double free of roi.file_path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ configure.scan
 src/kvazaar
 src/libkvazaar.so.*
 src/kvazaar.pc
+src/kvazaar.pc.temp
 src/version.h
 tests/kvazaar_tests
 tests/kvazaar_tests.trs

--- a/src/encoder.c
+++ b/src/encoder.c
@@ -153,6 +153,12 @@ encoder_control_t* kvz_encoder_control_init(const kvz_config *const cfg)
 
   // Take a copy of the config.
   memcpy(&encoder->cfg, cfg, sizeof(encoder->cfg));
+
+  // Copy the ROI file path
+  if (cfg->roi.file_path) {
+    encoder->cfg.roi.file_path = strdup(cfg->roi.file_path);
+  }
+
   // Set fields that are not copied to NULL.
   encoder->cfg.cqmfile = NULL;
   encoder->cfg.tiles_width_split = NULL;


### PR DESCRIPTION
## Changes

* Copy the `file_path` string after `memcpy` of `cfg`.

## Issues

* Closes #427 

## Details

* Check if the same change is needed for `optional_key` and `fastrd_learning_outdir_fn`.

