### PR TITLE
Correct testing instructions on linux.

### DIFF
--- a/README.md
+++ b/README.md
@@ -552,7 +552,8 @@ You can generate Doxygen documentation pages by running the command
         git submodule init
         git submodule update
 
-- On Linux, run ```make test```.
+- On Linux, configure kvazaar with ```./configure --enable-static```,
+  run ```make check```.
 
 
 ### Code style


### PR DESCRIPTION
Current ones fail to run if performed as described. There's no test build target in makefile, tests fail to link when static libraries aren't enabled.